### PR TITLE
Remove boilerplate and duplicate libraries

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,32 +21,11 @@ grade: stable
 confinement: strict
 base: core18
 
-plugs:
-    gnome-3-28-1804:
-      interface: content
-      target: $SNAP/gnome-platform
-      default-provider: gnome-3-28-1804
-    gtk-3-themes:
-      interface: content
-      target: $SNAP/data-dir/themes
-      default-provider: gtk-common-themes
-    icon-themes:
-      interface: content
-      target: $SNAP/data-dir/icons
-      default-provider: gtk-common-themes
-    sound-themes:
-      interface: content
-      target: $SNAP/data-dir/sounds
-      default-provider: gtk-common-themes
-
-environment:
-  XDG_DATA_DIRS: $SNAP/data-dir:$XDG_DATA_DIRS
-  GSETTINGS_SCHEMA_DIR: $SNAP/share/glib-2.0/schemas
-
 apps:
   dosbox-staging:
     command: desktop-launch dosbox
     plugs: [audio-playback, home, pulseaudio, desktop, desktop-legacy, wayland, x11, opengl, removable-media]
+    extensions: [gnome-3-28]
 
 parts:
   dosbox-staging:
@@ -93,20 +72,15 @@ parts:
       - -usr/share/lintian
       - -usr/share/man
 
-  desktop-gnome-platform:
-    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
-    source-subdir: gtk
-    plugin: make
-    make-parameters: ["FLAVOR=gtk3"]
-    build-packages:
-      - build-essential
-      - libgtk-3-dev
-    override-build: |
-      snapcraftctl build
-      mkdir -pv $SNAPCRAFT_PART_INSTALL/gnome-platform
-
-  # workaround snapcraft trying to outsmart us by copying ldd listed libraries
-  workaround:
+  cleanup:
+    after: [dosbox-staging]
     plugin: nil
-    prime:
-      - "-*"
+    build-snaps:
+      - core18
+      - gtk-common-themes
+      - gnome-3-28-1804
+    override-prime: |
+      set -eux
+      for snap in "core18" "gtk-common-themes" "gnome-3-28-1804"; do
+        cd "/snap/$snap/current" && find . -type f,l -exec rm -r "$SNAPCRAFT_PRIME/{}" \;
+      done


### PR DESCRIPTION
This uses the gnome-3-28 extension and then purges the duplicate libraries from the core and content snaps. It reduces the snap size from 35MB to about 2MB. You might want to test this before merging :)